### PR TITLE
Artem/42/handle websocket connection loss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /gremlin
 /vendor/
+.idea
 
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o

--- a/connection.go
+++ b/connection.go
@@ -43,12 +43,6 @@ func NewClient(logger log.Logger, urlStr string, origin string, maxConn []int, o
 		logger: logger,
 	}
 
-	// Check if connection is possible and close it
-	ws, err := pool.createSocket()
-	if err != nil {
-		return nil, err
-	}
-	ws.Close()
 	// Can make maxConn as an optional since we already have optional arguments here
 	if len(maxConn) > 0 {
 		pool.MaxConnections = maxConn[0]


### PR DESCRIPTION
Goes in pair with https://github.com/orkusinc/api/pull/2829
## Fix Description
Call chain is next 
```
api/common/utils/GremlinClient() > orkusinc/gremlin/connection/Exec(req)
```
In Exec method we Send message and read it response.
When connection is lost, we receive EOF error - and then  call `pool.createSocket()` method
`pool.createSocket()` method has backoff logic of creating new socket connection.
After connection recover we goto Send message again to not to lose this request.

Also we call `pool.createSocket()` method while creating newService - so service will be created only after gremlin server is up

## How I have tested it 
```
kubectl delete deployment gremlinserver-deployment
make launch-kubernetes
kubectl apply -f kubernetes/configs/minikube/deployment-gremlinserver.yaml
waitForPods.go
```